### PR TITLE
fix: remove key override and edge separation

### DIFF
--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -295,6 +295,8 @@ describe('CreateDatabaseManager', () => {
     expect(dbManager.saveEntity).toBeDefined();
     expect(dbManager.saveCondition).toBeDefined();
     expect(dbManager.saveGovernedAsCreditorByEdge).toBeDefined();
+    expect(dbManager.saveGovernedAsCreditorAccountByEdge).toBeDefined();
+    expect(dbManager.saveGovernedAsDebtorAccountByEdge).toBeDefined();
     expect(dbManager.saveGovernedAsDebtorByEdge).toBeDefined();
     expect(dbManager.getConditionsByEntity).toBeDefined();
     expect(dbManager.getEntityConditionsByGraph).toBeDefined();
@@ -328,6 +330,8 @@ describe('CreateDatabaseManager', () => {
     expect(await dbManager.saveCondition({} as EntityCondition)).toEqual('MOCK-SAVE');
     expect(await dbManager.saveGovernedAsCreditorByEdge('test1', 'test2', {} as ConditionEdge)).toEqual('MOCK-SAVE');
     expect(await dbManager.saveGovernedAsDebtorByEdge('test1', 'test2', {} as ConditionEdge)).toEqual('MOCK-SAVE');
+    expect(await dbManager.saveGovernedAsCreditorAccountByEdge('test1', 'test2', {} as ConditionEdge)).toEqual('MOCK-SAVE');
+    expect(await dbManager.saveGovernedAsDebtorAccountByEdge('test1', 'test2', {} as ConditionEdge)).toEqual('MOCK-SAVE');
     expect(await dbManager.getConditionsByEntity('test1', 'test2')).toEqual(['MOCK-QUERY']);
     expect(await dbManager.getEntityConditionsByGraph('test1', 'test2')).toEqual(['MOCK-QUERY']);
     expect(await dbManager.getAccountConditionsByGraph('test1', 'test2', 'ntty')).toEqual(['MOCK-QUERY']);
@@ -395,6 +399,8 @@ describe('CreateDatabaseManager', () => {
     expect(dbManager.getPacs002Edge).toBeDefined();
     expect(dbManager.getDebtorPacs002Edges).toBeDefined();
     expect(dbManager.getSuccessfulPacs002Edges).toBeDefined();
+    expect(dbManager.saveGovernedAsCreditorAccountByEdge).toBeDefined();
+    expect(dbManager.saveGovernedAsDebtorAccountByEdge).toBeDefined();
     expect(dbManager.getDebtorPacs008Edges).toBeDefined();
     expect(dbManager.getCreditorPacs008Edges).toBeDefined();
     expect(dbManager.getPreviousPacs008Edges).toBeDefined();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.1",
+  "version": "4.2.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "4.2.0-alpha.1",
+      "version": "4.2.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -126,13 +126,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.4.tgz",
+      "integrity": "sha512-NFtZmZsyzDPJnk9Zg3BbTfKKc9UlHYzD0E//p2Z3B9nCwwtJW9T0gVbCz8+fBngnn4zf1Dr3IK8PHQQHq0lDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.4",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -374,13 +374,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.25.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -613,13 +613,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-      "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -644,17 +644,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.4",
+        "@babel/parser": "^7.25.4",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/types": "^7.25.4",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@elastic/transport": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.7.0.tgz",
-      "integrity": "sha512-IqXT7a8DZPJtqP2qmX1I2QKmxYyN27kvSW4g6pInESE1SuGwZDp2FxHJ6W2kwmYOJwQdAt+2aWwzXO5jHo9l4A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.7.1.tgz",
+      "integrity": "sha512-2eeMVkz57Ayxv+UAZkIKzzrUu7nm96jr3+N3kLfbBqALYe2jwDpLr9pR0jc/x9HyJKAM909YGaNlHFDZeb0+Mw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.x",
@@ -2070,9 +2070,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
-      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4022,9 +4022,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.12.tgz",
-      "integrity": "sha512-tIhPkdlEoCL1Y+PToq3zRNehUaKp3wBX/sr7aclAWdIWjvqAe/Im/H0SiCM4c1Q8BLPHCdoJTol+ZblflydehA==",
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5619,9 +5619,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
-      "integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5869,9 +5869,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -8446,9 +8446,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
-      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.1",
+  "version": "4.2.0-alpha.2",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/builders/pseudonymsBuilder.ts
+++ b/src/builders/pseudonymsBuilder.ts
@@ -362,7 +362,7 @@ export async function pseudonymsBuilder(manager: DatabaseManagerType, pseudonyms
     const result = await (
       await manager._pseudonymsDb?.query<RawConditionResponse>(aql`
       LET gov_cred = (
-          FOR edge IN governed_as_creditor_by
+          FOR edge IN governed_as_creditor_account_by
           ${filterAql}
           RETURN {
               edge: edge,
@@ -372,7 +372,7 @@ export async function pseudonymsBuilder(manager: DatabaseManagerType, pseudonyms
       )
       
       LET gov_debtor = (
-          FOR edge IN governed_as_debtor_by
+          FOR edge IN governed_as_debtor_account_by
           ${filterAql}
           RETURN {
               edge: edge,
@@ -443,28 +443,44 @@ export async function pseudonymsBuilder(manager: DatabaseManagerType, pseudonyms
 
   manager.saveGovernedAsCreditorByEdge = async (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => {
     const db = manager._pseudonymsDb?.collection(dbPseudonyms.governed_as_creditor_by);
-    const condId = conditionId.substring(conditionId.indexOf('/') + 1, conditionId.length);
-    const accEntId = accountEntityId.substring(accountEntityId.indexOf('/') + 1, accountEntityId.length);
-    const _key = `${condId}${accEntId}`;
     const _from = accountEntityId;
     const _to = conditionId;
 
     return await db?.save(
-      { _key, _from, _to, evtTp: conditionEdge.evtTp, incptnDtTm: conditionEdge.incptnDtTm, xprtnDtTm: conditionEdge?.xprtnDtTm },
+      { _from, _to, evtTp: conditionEdge.evtTp, incptnDtTm: conditionEdge.incptnDtTm, xprtnDtTm: conditionEdge?.xprtnDtTm },
       { overwriteMode: 'ignore' },
     );
   };
 
   manager.saveGovernedAsDebtorByEdge = async (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => {
-    const condId = conditionId.substring(conditionId.indexOf('/') + 1, conditionId.length);
-    const accEntId = accountEntityId.substring(accountEntityId.indexOf('/') + 1, accountEntityId.length);
     const db = manager._pseudonymsDb?.collection(dbPseudonyms.governed_as_debtor_by);
-    const _key = `${condId}${accEntId}`;
     const _from = accountEntityId;
     const _to = conditionId;
 
     return await db?.save(
-      { _key, _from, _to, evtTp: conditionEdge.evtTp, incptnDtTm: conditionEdge.incptnDtTm, xprtnDtTm: conditionEdge?.xprtnDtTm },
+      { _from, _to, evtTp: conditionEdge.evtTp, incptnDtTm: conditionEdge.incptnDtTm, xprtnDtTm: conditionEdge?.xprtnDtTm },
+      { overwriteMode: 'ignore' },
+    );
+  };
+
+  manager.saveGovernedAsCreditorAccountByEdge = async (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => {
+    const db = manager._pseudonymsDb?.collection(dbPseudonyms.governed_as_creditor_account_by);
+    const _from = accountEntityId;
+    const _to = conditionId;
+
+    return await db?.save(
+      { _from, _to, evtTp: conditionEdge.evtTp, incptnDtTm: conditionEdge.incptnDtTm, xprtnDtTm: conditionEdge?.xprtnDtTm },
+      { overwriteMode: 'ignore' },
+    );
+  };
+
+  manager.saveGovernedAsDebtorAccountByEdge = async (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => {
+    const db = manager._pseudonymsDb?.collection(dbPseudonyms.governed_as_debtor_account_by);
+    const _from = accountEntityId;
+    const _to = conditionId;
+
+    return await db?.save(
+      { _from, _to, evtTp: conditionEdge.evtTp, incptnDtTm: conditionEdge.incptnDtTm, xprtnDtTm: conditionEdge?.xprtnDtTm },
       { overwriteMode: 'ignore' },
     );
   };

--- a/src/interfaces/ArangoCollections.ts
+++ b/src/interfaces/ArangoCollections.ts
@@ -16,6 +16,8 @@ const schema = {
     conditions: 'conditions',
     governed_as_debtor_by: 'governed_as_debtor_by',
     governed_as_creditor_by: 'governed_as_creditor_by',
+    governed_as_debtor_account_by: 'governed_as_debtor_account_by',
+    governed_as_creditor_account_by: 'governed_as_creditor_account_by',
   },
   config: {
     ruleConfiguration: 'ruleConfiguration',

--- a/src/interfaces/database/PseudonymsDB.ts
+++ b/src/interfaces/database/PseudonymsDB.ts
@@ -296,6 +296,23 @@ export interface PseudonymsDB {
    * @memberof PseudonymsDB
    */
   saveGovernedAsDebtorByEdge: (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => Promise<unknown>;
+  /**
+   * @param conditionId string condition identifier we are storing the edge connect
+   * @param accountEntityId string account or entity identifier we are storing the edge connect
+   * @param conditionEdge condition edge for account or entity to condition
+   *
+   * @memberof PseudonymsDB
+   */
+  saveGovernedAsDebtorAccountByEdge: (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => Promise<unknown>;
+
+  /**
+   * @param conditionId string condition identifier we are storing the edge connect
+   * @param accountEntityId string account or entity identifier we are storing the edge connect
+   * @param conditionEdge condition edge for account or entity to condition
+   *
+   * @memberof PseudonymsDB
+   */
+  saveGovernedAsCreditorAccountByEdge: (conditionId: string, accountEntityId: string, conditionEdge: ConditionEdge) => Promise<unknown>;
 
   /**
    * @param entityId string of identifier for entity being retrieved


### PR DESCRIPTION
## What did we change?
Removed specifying keys for edges. Also created two new methods for account related edges. Updated account conditions retrieval query to use the new edges.

## Why are we doing this?
https://github.com/frmscoe/admin-service/issues/64 and https://github.com/frmscoe/admin-service/issues/60

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done