### PR TITLE
feat: proto encode/decode EFRUP conditions 

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createConditionsBuffer, decodeConditionsBuffer } from '../src/helpers/protobuf';
+import { Acct } from '../src/interfaces/event-flow/EntityConditionEdge';
+
+describe('Should point to correct collections in transactionHistory', () => {
+  test('se/deserialise EFRuP conditions', () => {
+    const acct: Acct = {
+      id: '1010101010',
+      schmeNm: {
+        prtry: 'Mxx',
+      },
+      agt: {
+        finInstnId: {
+          clrSysMmbId: {
+            mmbId: 'dfsp001',
+          },
+        },
+      },
+    };
+    const conditions = [
+      {
+        condId: '26819',
+        condTp: 'non-overridable-block',
+        incptnDtTm: '2024-09-01T24:00:00.999Z',
+        xprtnDtTm: '2024-09-03T24:00:00.999Z',
+        condRsn: 'R001',
+        usr: 'bob',
+        creDtTm: '2024-08-23T11:46:53.091Z',
+        prsptvs: [
+          {
+            prsptv: 'governed_as_creditor_by',
+            evtTp: ['pacs.008.001.10', 'pacs.002.001.12'],
+            incptnDtTm: '2024-09-01T24:00:00.999Z',
+            xprtnDtTm: '2024-09-03T24:00:00.999Z',
+          },
+          {
+            prsptv: 'governed_as_debtor_by',
+            evtTp: ['pacs.008.001.10', 'pacs.002.001.12'],
+            incptnDtTm: '2024-09-01T24:00:00.999Z',
+            xprtnDtTm: '2024-09-03T24:00:00.999Z',
+          },
+        ],
+      },
+    ];
+
+    const entity = {
+      id: '+27733161225',
+      schmeNm: {
+        prtry: 'MSISDN',
+      },
+    };
+    const accountConditions = { acct: acct, conditions };
+    const bufAcc = createConditionsBuffer(accountConditions);
+    expect(bufAcc).toBeDefined();
+
+    const deserialisedAccConditions = decodeConditionsBuffer(bufAcc!);
+    expect(deserialisedAccConditions).toBeDefined();
+    expect(deserialisedAccConditions).toEqual(accountConditions);
+
+    const entityConditons = { ntty: entity, conditions };
+    const bufEntity = createConditionsBuffer(entityConditons);
+    expect(bufEntity).toBeDefined();
+
+    const deserialisedEntityConditions = decodeConditionsBuffer(bufEntity!);
+    expect(deserialisedEntityConditions).toBeDefined();
+    expect(deserialisedEntityConditions).toEqual(entityConditons);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.2",
+  "version": "4.2.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "4.2.0-alpha.2",
+      "version": "4.2.0-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -126,13 +126,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.25.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.4",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -374,13 +374,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.25.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -613,13 +613,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-      "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -644,17 +644,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.4",
+        "@babel/parser": "^7.25.4",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/types": "^7.25.4",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@elastic/transport": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.7.0.tgz",
-      "integrity": "sha512-IqXT7a8DZPJtqP2qmX1I2QKmxYyN27kvSW4g6pInESE1SuGwZDp2FxHJ6W2kwmYOJwQdAt+2aWwzXO5jHo9l4A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.7.1.tgz",
+      "integrity": "sha512-2eeMVkz57Ayxv+UAZkIKzzrUu7nm96jr3+N3kLfbBqALYe2jwDpLr9pR0jc/x9HyJKAM909YGaNlHFDZeb0+Mw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.x",
@@ -2070,9 +2070,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
-      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4022,9 +4022,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.12.tgz",
-      "integrity": "sha512-tIhPkdlEoCL1Y+PToq3zRNehUaKp3wBX/sr7aclAWdIWjvqAe/Im/H0SiCM4c1Q8BLPHCdoJTol+ZblflydehA==",
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5619,9 +5619,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
-      "integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5869,9 +5869,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -8446,9 +8446,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
-      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.3",
+  "version": "4.2.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "4.2.0-alpha.3",
+      "version": "4.2.0-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.2",
+  "version": "4.2.0-alpha.3",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.3",
+  "version": "4.2.0-alpha.4",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/helpers/proto/EFRuP.proto
+++ b/src/helpers/proto/EFRuP.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+message ClearingSystemMemberId {
+    string mmbId = 1;
+}
+
+message FinancialInstitutionId {
+    ClearingSystemMemberId clrSysMmbId = 1;
+}
+
+message Agent {
+    FinancialInstitutionId finInstnId = 1;
+}
+
+message Account {
+    string id = 1;
+    SchemeName schmeNm = 2;
+    Agent agt = 3;
+}
+
+message SchemeName {
+    string prtry = 1;
+}
+
+message Entity {
+    string id = 1;
+    SchemeName schmeNm = 2;
+}
+
+message Perspective {
+    string prsptv = 1;
+    repeated string evtTp = 2;
+    string incptnDtTm = 3;
+    string xprtnDtTm = 4;
+}
+
+message ConditionDetails {
+    string condId = 1;
+    string condTp = 2;
+    string incptnDtTm = 3;
+    string xprtnDtTm = 4;
+    string condRsn = 5;
+    string usr = 6;
+    string creDtTm = 7;
+    repeated Perspective prsptvs = 8;
+}
+
+message Conditions {
+    Entity ntty = 1;
+    Account acct = 2;
+    repeated ConditionDetails conditions = 3;
+}

--- a/src/helpers/protobuf.ts
+++ b/src/helpers/protobuf.ts
@@ -3,7 +3,7 @@
 import protobuf from 'protobufjs';
 import path from 'node:path';
 import { type LogMessage as LogMessageType } from './proto/lumberjack/LogMessage';
-import { type ConditionResponse } from '../interfaces/event-flow/ConditionDetails';
+import { type AccountConditionResponse, type EntityConditionResponse } from '../interfaces/event-flow/ConditionDetails';
 
 const root = protobuf.loadSync(path.join(__dirname, '/proto/Full.proto'));
 const FRMSMessage = root.lookupType('FRMSMessage');
@@ -18,7 +18,7 @@ const ConditionsMessage = conditions.lookupType('Conditions');
  * Create a Message `Buffer` derived from a byte array resulting from the input type
  *
  * @param {Record<string, unknown>} data The object to serialise to a `Buffer`
- * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occured
+ * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occurred
  */
 export const createMessageBuffer = (data: Record<string, unknown>): Buffer | undefined => {
   try {
@@ -34,7 +34,7 @@ export const createMessageBuffer = (data: Record<string, unknown>): Buffer | und
  * Create a Log `Buffer` derived from a byte array resulting from the input type
  *
  * @param {Record<string, unknown>} data The object to serialise to a `Buffer`
- * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occured
+ * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occurred
  */
 export const createLogBuffer = (data: Record<string, unknown>): Buffer | undefined => {
   try {
@@ -47,12 +47,12 @@ export const createLogBuffer = (data: Record<string, unknown>): Buffer | undefin
 };
 
 /**
- * Create a ConditionResponse `Buffer` derived from a byte array resulting from the input type
+ * Create a  AccountConditionResponse | EntityConditionResponse `Buffer` derived from a byte array resulting from the input type
  *
- * @param {ConditionResponse} data The object to serialise to a `Buffer`
- * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occured
+ * @param { AccountConditionResponse | EntityConditionResponse} data The object to serialise to a `Buffer`
+ * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occurred
  */
-export const createConditionsBuffer = (data: ConditionResponse): Buffer | undefined => {
+export const createConditionsBuffer = (data: AccountConditionResponse | EntityConditionResponse): Buffer | undefined => {
   try {
     const msg = ConditionsMessage.create(data);
     const enc = ConditionsMessage.encode(msg).finish() as Buffer;
@@ -63,21 +63,21 @@ export const createConditionsBuffer = (data: ConditionResponse): Buffer | undefi
 };
 
 /**
- * Decodes a ConditionResponse `Buffer` derived from a byte array resulting from the input type
+ * Decodes a  AccountConditionResponse | EntityConditionResponse `Buffer` derived from a byte array resulting from the input type
  *
- * @param {Buffer} buffer The byte array to decode to a `ConditionResponse`
- * @returns {ConditionResponse | undefined} The resulting `ConditionResponse`, or `undefined` if an error occured
+ * @param {Buffer} buffer The byte array to decode to a `AccountConditionResponse | EntityConditionResponse`
+ * @returns { AccountConditionResponse | EntityConditionResponse | undefined} The resulting ` AccountConditionResponse | EntityConditionResponse`, or `undefined` if an error occurred
  */
-export const decodeConditionsBuffer = (buffer: Buffer): ConditionResponse | undefined => {
+export const decodeConditionsBuffer = (buffer: Buffer): AccountConditionResponse | EntityConditionResponse | undefined => {
   const decodedMessage = ConditionsMessage.decode(buffer);
-  return ConditionsMessage.toObject(decodedMessage) as ConditionResponse;
+  return ConditionsMessage.toObject(decodedMessage) as AccountConditionResponse | EntityConditionResponse;
 };
 
 /**
  * Decodes a Log `Buffer` derived from a byte array resulting in a concrete `LogMessage` type
  *
  * @param {Buffer} buffer The byte array to decode to a `LogMessage`
- * @returns {LogMessage | undefined} The resulting `LogMessage`, or `undefined` if an error occured
+ * @returns {LogMessage | undefined} The resulting `LogMessage`, or `undefined` if an error occurred
  */
 export const decodeLogBuffer = (buffer: Buffer): LogMessageType | undefined => {
   const decodedMessage = LogMessage.decode(buffer);

--- a/src/helpers/protobuf.ts
+++ b/src/helpers/protobuf.ts
@@ -3,11 +3,16 @@
 import protobuf from 'protobufjs';
 import path from 'node:path';
 import { type LogMessage as LogMessageType } from './proto/lumberjack/LogMessage';
+import { type ConditionResponse } from '../interfaces/event-flow/ConditionDetails';
+
 const root = protobuf.loadSync(path.join(__dirname, '/proto/Full.proto'));
 const FRMSMessage = root.lookupType('FRMSMessage');
 
 const log = protobuf.loadSync(path.join(__dirname, '/proto/Lumberjack.proto'));
 const LogMessage = log.lookupType('LogMessage');
+
+const conditions = protobuf.loadSync(path.join(__dirname, '/proto/EFRuP.proto'));
+const ConditionsMessage = conditions.lookupType('Conditions');
 
 /**
  * Create a Message `Buffer` derived from a byte array resulting from the input type
@@ -39,6 +44,33 @@ export const createLogBuffer = (data: Record<string, unknown>): Buffer | undefin
   } catch (error) {
     return undefined;
   }
+};
+
+/**
+ * Create a ConditionResponse `Buffer` derived from a byte array resulting from the input type
+ *
+ * @param {ConditionResponse} data The object to serialise to a `Buffer`
+ * @returns {Buffer | undefined} The resulting `Buffer`, or `undefined` if an error occured
+ */
+export const createConditionsBuffer = (data: ConditionResponse): Buffer | undefined => {
+  try {
+    const msg = ConditionsMessage.create(data);
+    const enc = ConditionsMessage.encode(msg).finish() as Buffer;
+    return enc;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+/**
+ * Decodes a ConditionResponse `Buffer` derived from a byte array resulting from the input type
+ *
+ * @param {Buffer} buffer The byte array to decode to a `ConditionResponse`
+ * @returns {ConditionResponse | undefined} The resulting `ConditionResponse`, or `undefined` if an error occured
+ */
+export const decodeConditionsBuffer = (buffer: Buffer): ConditionResponse | undefined => {
+  const decodedMessage = ConditionsMessage.decode(buffer);
+  return ConditionsMessage.toObject(decodedMessage) as ConditionResponse;
 };
 
 /**

--- a/src/interfaces/event-flow/ConditionDetails.ts
+++ b/src/interfaces/event-flow/ConditionDetails.ts
@@ -16,9 +16,12 @@ export interface ConditionDetails extends Pick<Condition, 'incptnDtTm' | 'xprtnD
   prsptvs: Array<Pick<Condition, 'prsptv' | 'evtTp' | 'incptnDtTm' | 'xprtnDtTm'>>;
 }
 
-export interface ConditionResponse {
-  // one of ntty and acct, never both
-  ntty?: Ntty;
-  acct?: Acct;
+export interface EntityConditionResponse {
+  ntty: Ntty;
+  conditions: ConditionDetails[];
+}
+
+export interface AccountConditionResponse {
+  acct: Acct;
   conditions: ConditionDetails[];
 }

--- a/src/interfaces/event-flow/ConditionDetails.ts
+++ b/src/interfaces/event-flow/ConditionDetails.ts
@@ -1,0 +1,24 @@
+import type { MetaData } from '../metaData';
+import type { Condition } from './Condition';
+import type { Edge, Entity, Acct, Ntty } from './EntityConditionEdge';
+
+export interface Entry {
+  edge: Edge;
+  entity: Entity;
+  condition: MetaData & Condition;
+}
+export interface ConditionDetails extends Pick<Condition, 'incptnDtTm' | 'xprtnDtTm'> {
+  condId: string;
+  condTp: string;
+  condRsn: string;
+  usr: string;
+  creDtTm: string;
+  prsptvs: Array<Pick<Condition, 'prsptv' | 'evtTp' | 'incptnDtTm' | 'xprtnDtTm'>>;
+}
+
+export interface ConditionResponse {
+  // one of ntty and acct, never both
+  ntty?: Ntty;
+  acct?: Acct;
+  conditions: ConditionDetails[];
+}


### PR DESCRIPTION
## What did we change?
Add helper functions to encode/decode EFRuP conditions to Buffers

## Why are we doing this?
All cache writes should store buffers

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done