### PR TITLE
refactor: bump lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.6",
+  "version": "4.2.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "4.2.0-alpha.6",
+      "version": "4.2.0-alpha.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.6",
+  "version": "4.2.0-alpha.7",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

**This version contains Changes of**f: https://github.com/tazama-lf/frms-coe-lib/pull/167

## What did we change?
We are bumping the version of the library

## Why are we doing this?
Because we have published the current version

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done