### PR TITLE
fix: allow forever cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.7",
+  "version": "4.2.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "4.2.0-alpha.7",
+      "version": "4.2.0-alpha.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "4.2.0-alpha.7",
+  "version": "4.2.0-alpha.8",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -163,8 +163,13 @@ export class RedisService {
    * Much like `setJson()`, but without the JSON restriction,
    * This version accepts `Buffer` and `number` times in addition
    */
-  async set(key: string, value: RedisData, expire: number): Promise<void> {
-    const res = await this._redisClient.set(key, value, 'EX', expire);
+  async set(key: string, value: RedisData, expire?: number): Promise<void> {
+    let res;
+    if (expire) {
+      res = await this._redisClient.set(key, value, 'EX', expire);
+    } else {
+      res = await this._redisClient.set(key, value);
+    }
 
     if (res !== 'OK') {
       throw new Error('Error while setting key in redis');


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
1. set method of caching data

## Why are we doing this?
1. To allow integrators to cache forever

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

PR related to issue: https://github.com/frmscoe/admin-service/issues/81