### PR TITLE
refactor: reuse available redis config

### DIFF
--- a/src/helpers/env/redis.config.ts
+++ b/src/helpers/env/redis.config.ts
@@ -21,7 +21,7 @@ export const validateRedisConfig = (authEnabled: boolean): RedisConfig => {
   return {
     db: validateEnvVar('REDIS_DATABASE', 'string'),
     password,
-    servers: validateEnvVar('REDIS_SERVERS', 'string'),
+    servers: JSON.parse(validateEnvVar('REDIS_SERVERS', 'string')),
     isCluster: validateEnvVar('REDIS_IS_CLUSTER', 'boolean'),
   };
 };

--- a/src/helpers/env/redis.config.ts
+++ b/src/helpers/env/redis.config.ts
@@ -1,21 +1,5 @@
 import { validateEnvVar } from '.';
-
-/**
- * Interface representing the configuration for Redis.
- */
-export interface RedisConfig {
-  /** The database number to use. */
-  db: string;
-
-  /** The authentication password for Redis (optional). */
-  auth?: string;
-
-  /** The servers for the Redis instance(s). */
-  servers: string;
-
-  /** Indicates whether the Redis configuration is for a cluster. */
-  isCluster: boolean;
-}
+import { type RedisConfig } from '../../interfaces';
 
 /**
  * Validates and retrieves the Redis configuration from environment variables.
@@ -28,15 +12,15 @@ export interface RedisConfig {
  * const redisConfig = validateRedisConfig(true);
  */
 export const validateRedisConfig = (authEnabled: boolean): RedisConfig => {
-  let auth: string | undefined;
+  let password = '';
 
   if (authEnabled) {
-    auth = validateEnvVar('REDIS_AUTH', 'string');
+    password = validateEnvVar('REDIS_AUTH', 'string');
   }
 
   return {
     db: validateEnvVar('REDIS_DATABASE', 'string'),
-    auth,
+    password,
     servers: validateEnvVar('REDIS_SERVERS', 'string'),
     isCluster: validateEnvVar('REDIS_IS_CLUSTER', 'boolean'),
   };


### PR DESCRIPTION
## What did we change?
Reused the existing RedisConfig

## Why are we doing this?
No dupes

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done