### PR TITLE
fix: db user is not required if auth is disabled

### DIFF
--- a/src/helpers/env/database.config.ts
+++ b/src/helpers/env/database.config.ts
@@ -61,12 +61,13 @@ export const validateDatabaseConfig = (authEnabled: boolean, database: Database)
   }
 
   const password = validateEnvVar<string>(`${prefix}_PASSWORD`, 'string', !authEnabled);
+  const user = validateEnvVar<string>(`${prefix}_USER`, 'string', !authEnabled);
 
   return {
     databaseName: validateEnvVar(prefix, 'string'),
     password,
     url: validateEnvVar(`${prefix}_URL`, 'string'),
-    user: validateEnvVar(`${prefix}_USER`, 'string'),
+    user,
     certPath: validateEnvVar(`${prefix}_CERT_PATH`, 'string'),
     localCacheTTL: validateEnvVar<number>('CACHETTL', 'number', true),
     localCacheEnabled: validateEnvVar<boolean>('CACHE_ENABLED', 'boolean', true),

--- a/src/helpers/env/index.ts
+++ b/src/helpers/env/index.ts
@@ -8,7 +8,7 @@ import { validateProcessorConfig } from './processor.config';
  * @template T - The expected type of the environment variable.
  * @param {string} name - The name of the environment variable to validate.
  * @param {'string' | 'number' | 'boolean'} type - The expected type of the environment variable.
- * @param {string} optional - Is this variable optional (Defaults to false)
+ * @param {boolean} optional - Is this variable optional (Defaults to false)
  * @returns {T} - The value of the environment variable, cast to the specified type.
  * @throws {Error} - Throws an error if the environment variable is not defined, or if the value cannot be converted to the specified type.
  *


### PR DESCRIPTION
## Why are we doing this?
Align auth state with variables

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done