### PR TITLE
fix: split cache options

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,13 @@ The JSON object example for dbManage configuration
       host: 'your-redis-host',
       port: 6379,
       password: 'your-redis-password',
+      distributedCacheEnabled: true;
+      distributedCacheTTL: 300;
     },
+    localConfig: {
+      localCacheEnabled: true;
+      localCacheTTL: 300;
+    }
 };
 
 ```

--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -4,7 +4,7 @@ import { AqlLiteral, isAqlQuery } from 'arangojs/aql';
 import { ConfigurationDB, PseudonymsDB, RedisService, TransactionDB, TransactionHistoryDB } from '../src';
 import * as isDatabaseReady from '../src/helpers/readyCheck';
 import { AccountType, ConditionEdge, EntityCondition, NetworkMap, Pacs002, TransactionRelationship, Typology } from '../src/interfaces';
-import { CreateDatabaseManager, DatabaseManagerInstance } from '../src/services/dbManager';
+import { CreateDatabaseManager, DatabaseManagerInstance, LocalCacheConfig, ManagerConfig } from '../src/services/dbManager';
 
 // redis and aragojs are mocked
 // setup.jest.js
@@ -35,8 +35,6 @@ const configurationConfig = {
   user: 'TestConfiguration',
   password: 'TestConfiguration',
   url: 'TestConfiguration',
-  localCacheEnabled: true,
-  localCacheTTL: 10,
 };
 
 const configurationConfigNoTTL = {
@@ -45,7 +43,6 @@ const configurationConfigNoTTL = {
   user: 'TestConfiguration',
   password: 'TestConfiguration',
   url: 'TestConfiguration',
-  localCacheEnabled: true,
 };
 
 const configurationConfigNoCache = {
@@ -91,12 +88,18 @@ const mockTR: TransactionRelationship = {
   Amt: 'MOCK-Amt',
   Ccy: 'MOCK-Ccy',
 };
+
+const localCacheOptions: LocalCacheConfig = {
+  localCacheEnabled: true,
+  localCacheTTL: 300,
+};
 const config = {
   redisConfig: redisConfig,
   transactionHistory: transactionHistoryConfig,
   configuration: configurationConfig,
   pseudonyms: pseudonymsConfig,
   networkMap: networkMapConfig,
+  localCacheConfig: localCacheOptions,
 };
 
 let globalManager: DatabaseManagerInstance<typeof config>;
@@ -108,6 +111,7 @@ beforeAll(async () => {
     configuration: configurationConfig,
     pseudonyms: pseudonymsConfig,
     networkMap: networkMapConfig,
+    localCacheConfig: localCacheOptions,
   };
   globalManager = await CreateDatabaseManager(config);
 });

--- a/src/helpers/env/database.config.ts
+++ b/src/helpers/env/database.config.ts
@@ -68,7 +68,5 @@ export const validateDatabaseConfig = (authEnabled: boolean, database: Database)
     url: validateEnvVar(`${prefix}_URL`, 'string'),
     user: validateEnvVar(`${prefix}_USER`, 'string'),
     certPath: validateEnvVar(`${prefix}_CERT_PATH`, 'string'),
-    localCacheTTL: validateEnvVar<number>('CACHETTL', 'number', true),
-    localCacheEnabled: validateEnvVar<boolean>('CACHE_ENABLED', 'boolean', true),
   };
 };

--- a/src/helpers/env/index.ts
+++ b/src/helpers/env/index.ts
@@ -2,6 +2,7 @@ import { validateDatabaseConfig } from './database.config';
 import { validateLogConfig, validateAPMConfig } from './monitoring.config';
 import { validateRedisConfig } from './redis.config';
 import { validateProcessorConfig } from './processor.config';
+import { validateLocalCacheConfig } from './localcache.config';
 /**
  * Validates and retrieves the specified environment variable.
  *
@@ -51,4 +52,11 @@ export function validateEnvVar<T>(name: string, type: 'string' | 'number' | 'boo
   }
 }
 
-export { validateDatabaseConfig, validateLogConfig, validateAPMConfig, validateRedisConfig, validateProcessorConfig };
+export {
+  validateDatabaseConfig,
+  validateLogConfig,
+  validateAPMConfig,
+  validateRedisConfig,
+  validateProcessorConfig,
+  validateLocalCacheConfig,
+};

--- a/src/helpers/env/localcache.config.ts
+++ b/src/helpers/env/localcache.config.ts
@@ -1,0 +1,18 @@
+import { validateEnvVar } from '.';
+import { type LocalCacheConfig } from '../../services/dbManager';
+
+/**
+ * Validates and retrieves the Local cache options configuration from environment variables.
+ *
+ * @returns {LocalCacheConfig} - The validated LocalCacheConfig configuration.
+ * @throws {Error} - Throws an error if required environment variables are not defined or invalid.
+ *
+ * @example
+ * const localCacheOptions = validateLocalCacheConfig();
+ */
+export const validateLocalCacheConfig = (): LocalCacheConfig => {
+  return {
+    localCacheEnabled: validateEnvVar('LOCAL_CACHE_ENABLED', 'boolean', true),
+    localCacheTTL: validateEnvVar('LOCAL_CACHETTL', 'number', true),
+  };
+};

--- a/src/helpers/env/redis.config.ts
+++ b/src/helpers/env/redis.config.ts
@@ -19,5 +19,7 @@ export const validateRedisConfig = (authEnabled: boolean): RedisConfig => {
     password,
     servers: JSON.parse(validateEnvVar('REDIS_SERVERS', 'string')),
     isCluster: validateEnvVar('REDIS_IS_CLUSTER', 'boolean'),
+    distributedCacheEnabled: validateEnvVar('DISTRIBUTED_CACHE_ENABLED', 'boolean', true),
+    distributedCacheTTL: validateEnvVar('DISTRIBUTED_CACHETTL', 'number', true),
   };
 };

--- a/src/interfaces/RedisConfig.ts
+++ b/src/interfaces/RedisConfig.ts
@@ -8,4 +8,6 @@ export interface RedisConfig {
   }>;
   password: string;
   isCluster: boolean;
+  distributedCacheEnabled?: boolean;
+  distributedCacheTTL?: number;
 }

--- a/src/services/dbManager.ts
+++ b/src/services/dbManager.ts
@@ -22,6 +22,9 @@ export interface DBConfig {
   password: string;
   databaseName: string;
   certPath: string;
+}
+
+export interface LocalCacheConfig {
   localCacheEnabled?: boolean;
   localCacheTTL?: number;
 }
@@ -32,6 +35,7 @@ interface ManagerConfig {
   transaction?: DBConfig;
   configuration?: DBConfig;
   redisConfig?: RedisConfig;
+  localCacheConfig?: LocalCacheConfig;
 }
 
 interface ManagerStatus {
@@ -80,7 +84,7 @@ export async function CreateDatabaseManager<T extends ManagerConfig>(config: T):
   }
 
   if (config.configuration) {
-    await configurationBuilder(manager, config.configuration);
+    await configurationBuilder(manager, config.configuration, config.localCacheConfig);
   }
 
   manager.isReadyCheck = () => readyChecks;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
1. Separated cache options

## Why are we doing this?
To ensure these options cache used by resource targeted only

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done