### PR TITLE
docs: add documentation for encapsulation of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,41 +239,39 @@ databaseManager = await CreateDatabaseManager(dbConfig);
 
 ### Environment Variables
 
-The `frms-coe-lib` library uses environment variables to configure logging for any processor that is using it the logging for more information about logging here is the [link](https://github.com/frmscoe/docs/blob/dev/Technical/Logging/The-Tazama-Logging-Framework.md) . Here are the key environment variables some variables are required only when NODE_ENV is set to `production`:
+In our system, all environment variables are processed using a validation algorithm that converts them into configurations for each third-party service. Validation is triggered during the instantiation of each class object, such as when creating an instance of `databaseManager` via the `CreateStorageManager` function. 
 
-**PROCESSOR ENVIRONMENT VARIABLES**
+### Third-Party Services
 
-| Variable Name | Purpose                             | Default value           | Requirement             |
-| ------------- | ----------------------------------- | ----------------------- | ----------------------- |
-| FUNCTION_NAME | Specifies the port number to use    | `null`                  | Mandatory               |
-| RULE_VERSION  | Specifies the NATS server address   | `null`                  | Optional                |
-| NODE_ENV      | Defines the NATS subject/topic name | `null`                  | Mandatory               |
+This validation mechanism applies specifically to third-party services. For processor-based configurations, we execute a specialized function called `validateProcessorConfig`. This function accommodates additional environment variables provided by the processor.
 
-**LOGSTASH ENVIRONMENT VARIABLES**
+### Interface for Optional Environment Variables
 
-| Variable Name  | Purpose                                                 | Default value | Requirement                     |
-| -------------- | ------------------------------------------------------- | ------------- | ------------------------------- |
-| LOGSTASH_LEVEL | Specifies the minimum log level to capture logs for     | `info`        | Optional                        |
-| LOGSTASH_PORT  | Specifies port of logstash from the server hosting it   | `0`           | Optional                        |
-| LOGSTASH_HOST  | Specifies address of the host that has logstash exposed | `null`        | Optional `Unless on Production` |
+The `validateProcessorConfig` function utilizes the following interface for optional environment variables:
 
-**ELASTIC ENVIRONMENT VARIABLES**
+```typescript
+export interface AdditionalConfig {
+  name: string;
+  type: 'string' | 'boolean' | 'number';
+  optional?: boolean;
+}
+```
 
-| Variable Name          | Purpose                                     | Default value           | Requirement                     |
-| ---------------------- | ------------------------------------------- | ----------------------- | ------------------------------- |
-| ELASTIC_SEARCH_VERSION | Specifies the Elasticsearch version         | `8.11`                  | Optional `Unless on Production` |
-| ELASTIC_HOST           | Specifies the Elasticsearch host            | `http://localhost:9200` | Optional `Unless on Production` |
-| ELASTIC_USERNAME       | Username for Elasticsearch authentication   | `''`                    | Optional `Unless on Production` |
-| ELASTIC_PASSWORD       | Password for Elasticsearch authentication   | `''`                    | Optional `Unless on Production` |
+By default, this function checks for the following environment variables:
 
-**APM ENVIRONMENT VARIABLES**
+- **NODE_ENV**
+- **MAX_CPU**
+- **FUNCTION_NAME**
 
-| Variable           | Purpose                                                              | Default value       | Requirement  |
-| ------------------ | -------------------------------------------------------------------- | ------------------- | ------------ |
-| APM_LOGGING        | Boolean to flag if you would like to have apm logging                | `true`              | Optional     |
-| APM_SECRET_TOKEN   | Token used for authentication and authorization with the APM system. | `''` _Deprecated_   | Optional     |
+### Third-Party Services Overview
 
+The third-party services we support include:
 
+- **ArangoDB**: For database operations.
+- **Logging**: Capable of sending logs to Pino or console/stdout.
+- **APM (Application Performance Monitoring)**: Integrated with Elastic for performance tracking.
+
+To see what are the variables required for each service please refer to VARIABLES.md document
 
 ### Configuration Options
 The ManagerConfig interface allows you to define which databases and services you wish to use. Each service can be optionally included in the configuration:
@@ -283,6 +281,7 @@ The ManagerConfig interface allows you to define which databases and services yo
 - **Transaction Database**: Handle transactional operations. `Optional`
 - **Configuration Database**: Store and retrieve application configurations. `Optional`
 - **Redis Cache**: Use Redis for caching to improve performance. `Optional`
+- **Local Cache**: Options for using local cache to improve performance. `Optional` Note: This object is heavily used by configuration builder
 
 ### Usage Example
 The JSON object example for dbManage configuration

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -63,7 +63,7 @@ Logging Class: This class needs configuration variables to check the environment
 | CONFIGURATION_DATABASE_URL | String | No |   
 | CONFIGURATION_DATABASE_PASSWORD |  String | if specified No |  
 
-##### 3. EVALUATION DATABASE 
+##### 4. EVALUATION DATABASE 
 
 | Variables | DataType | Optional | 
 | -------- | ------- | ------- | 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -40,8 +40,8 @@ Logging Class: This class needs configuration variables to check the environment
 | -------- | ------- | ------- | 
 | TRANSACTION_HISTORY_DATABASE | String | No | 
 | TRANSACTION_HISTORY_DATABASE_URL | String | No | 
-| TRANSACTION_HISTORY_DATABASE_USER | String | No | 
-| TRANSACTION_HISTORY_DATABASE_PASSWORD |  String | No | 
+| TRANSACTION_HISTORY_DATABASE_USER | String | if specified No | 
+| TRANSACTION_HISTORY_DATABASE_PASSWORD |  String | if specified No | 
 | TRANSACTION_HISTORY_DATABASE_CERT_PATH |  String | No | 
 
 ##### 2. PSEUDONYMS DATABASE 
@@ -49,8 +49,8 @@ Logging Class: This class needs configuration variables to check the environment
 | Variables | DataType | Optional | 
 | -------- | ------- | ------- | 
 | PSEUDONYMS_DATABASE_URL |  String | No | 
-| PSEUDONYMS_DATABASE_USER |  String | No |  
-| PSEUDONYMS_DATABASE_PASSWORD |  String | No | 
+| PSEUDONYMS_DATABASE_USER |  String | if specified No |  
+| PSEUDONYMS_DATABASE_PASSWORD |  String | if specified No | 
 | PSEUDONYMS_DATABASE_CERT_PATH |  String | No | 
 
 ##### 3. CONFIGURATION DATABASE 
@@ -59,9 +59,9 @@ Logging Class: This class needs configuration variables to check the environment
 | -------- | ------- | ------- | 
 | CONFIGURATION_DATABASE_CERT_PATH |  String | No | 
 | CONFIGURATION_DATABASE |  String | No | 
-| CONFIGURATION_DATABASE_USER |  String | No |  
+| CONFIGURATION_DATABASE_USER |  String | if specified No |  
 | CONFIGURATION_DATABASE_URL | String | No |   
-| CONFIGURATION_DATABASE_PASSWORD |  String | No |  
+| CONFIGURATION_DATABASE_PASSWORD |  String | if specified No |  
 
 ##### 3. EVALUATION DATABASE 
 
@@ -69,8 +69,8 @@ Logging Class: This class needs configuration variables to check the environment
 | -------- | ------- | ------- | 
 | TRANSACTION_DATABASE_CERT_PATH |  String | No |  
 | TRANSACTION_DATABASE_URL |  String | No |  
-| TRANSACTION_DATABASE_USER |  String | No |  
-| TRANSACTION_DATABASE_PASSWORD |  String | No | 
+| TRANSACTION_DATABASE_USER |  String | if specified No |  
+| TRANSACTION_DATABASE_PASSWORD |  String | if specified No | 
 | TRANSACTION_DATABASE | String | No |  
 
 ### Elastic Variables

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -1,0 +1,93 @@
+# Environment Variables
+
+## Overview
+All environment variables are essential when instantiating each object's classes within the library. This design enables the library to require environment variables on demand, ensuring that each class has the necessary configuration before it operates.
+
+**Required Environment Variables**
+Each class may depend on specific environment variables for proper instantiation and functionality. Ensure that all required variables are set in your environment before running the application.
+
+**Processor-Based Validation**
+Certain classes may require processor-based validation objects to determine additional environment variables. For example:
+
+Logging Class: This class needs configuration variables to check the environment the processor is running on. Depending on the setup, it will log messages either through Pino or the console.
+
+
+### General Variables
+
+| Variables    |  DataType | Optional |
+| -------- | -------- | -------- | 
+| FUNCTION_NAME  | String | No |
+| NODE_ENV | String | No |
+| MAX_CPU | Number | No |
+
+
+
+### Redis Variables
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- | 
+| REDIS_DB | Number | No | 
+| REDIS_AUTH | String | No |
+| REDIS_SERVERS | String | No | 
+| REDIS_IS_CLUSTER | Boolean | No |
+
+ 
+### Database Variables (Arango)
+
+ ##### 1. TRANSACTION HISTORY DATABASE 
+
+| Variables | DataType | Optional |
+| -------- | ------- | ------- | 
+| TRANSACTION_HISTORY_DATABASE | String | No | 
+| TRANSACTION_HISTORY_DATABASE_URL | String | No | 
+| TRANSACTION_HISTORY_DATABASE_USER | String | No | 
+| TRANSACTION_HISTORY_DATABASE_PASSWORD |  String | No | 
+| TRANSACTION_HISTORY_DATABASE_CERT_PATH |  String | No | 
+
+##### 2. PSEUDONYMS DATABASE 
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- | 
+| PSEUDONYMS_DATABASE_URL |  String | No | 
+| PSEUDONYMS_DATABASE_USER |  String | No |  
+| PSEUDONYMS_DATABASE_PASSWORD |  String | No | 
+| PSEUDONYMS_DATABASE_CERT_PATH |  String | No | 
+
+##### 3. CONFIGURATION DATABASE 
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- | 
+| CONFIGURATION_DATABASE_CERT_PATH |  String | No | 
+| CONFIGURATION_DATABASE |  String | No | 
+| CONFIGURATION_DATABASE_USER |  String | No |  
+| CONFIGURATION_DATABASE_URL | String | No |   
+| CONFIGURATION_DATABASE_PASSWORD |  String | No |  
+
+##### 3. EVALUATION DATABASE 
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- | 
+| TRANSACTION_DATABASE_CERT_PATH |  String | No |  
+| TRANSACTION_DATABASE_URL |  String | No |  
+| TRANSACTION_DATABASE_USER |  String | No |  
+| TRANSACTION_DATABASE_PASSWORD |  String | No | 
+| TRANSACTION_DATABASE | String | No |  
+
+### Elastic Variables
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- |
+| APM_ACTIVE | Boolean | No | 
+| APM_SERVICE_NAME | String | No unless APM_ACTIVE=`false` | 
+| APM_URL | String | No unless APM_ACTIVE=`false` | 
+| APM_SECRET_TOKEN | String | No unless APM_ACTIVE=`false` |
+
+### Logging Variables
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- | 
+| LOGSTASH_HOST | String | Yes | 
+| LOGSTASH_PORT | String | Yes | 
+| LOGSTASH_LEVEL | String | Yes | 
+| SIDECAR_HOST | String | Yes | 
+


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Added documentation to explain the behavior of the library after encapsulation of the environment variables

## Why are we doing this?
To allow ease of integration of the library

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [x] Unit tests passing and Documentation done