### PR TITLE
feat: Multi currency cache

### DIFF
--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -441,6 +441,10 @@ describe('CreateDatabaseManager', () => {
     expect(dbManager.addOneGetCount).toBeDefined();
   });
 
+  it(`should return a networkmap`, async () => {
+    expect(await globalManager.getNetworkMap()).toEqual(['MOCK-QUERY']);
+  });
+
   it('should not try use cache for getRuleConfig when cached not enabled', async () => {
     const confConfig = {
       configuration: {
@@ -465,6 +469,22 @@ describe('CreateDatabaseManager', () => {
     expect(await dbManager.getRuleConfig('test-ruleid', 'test-cfg')).toEqual(['MOCK-QUERY']);
 
     dbManager.quit();
+  });
+
+  it('should try to use cache for getRuleConfig when cached enabled', async () => {
+    jest.spyOn(globalManager._configuration, 'query').mockImplementation((query: string | AqlLiteral): Promise<any> => {
+      return new Promise((resolve, reject) => {
+        isAqlQuery(query)
+          ? resolve({
+              batches: {
+                all: jest.fn().mockImplementation(() => [['MOCK-QUERY']]),
+              },
+            })
+          : reject(new Error('Not AQL Query'));
+      });
+    });
+
+    expect(await globalManager.getRuleConfig('test-ruleid', 'test-cfg')).toEqual([['MOCK-QUERY']]);
   });
 
   it('should not try use cache for getTransactionConfig when cached not enabled', async () => {
@@ -493,6 +513,22 @@ describe('CreateDatabaseManager', () => {
     dbManager.quit();
   });
 
+  it('should try to use cache for getTransactionConfig when cached enabled', async () => {
+    jest.spyOn(globalManager._configuration, 'query').mockImplementation((query: string | AqlLiteral): Promise<any> => {
+      return new Promise((resolve, reject) => {
+        isAqlQuery(query)
+          ? resolve({
+              batches: {
+                all: jest.fn().mockImplementation(() => [['MOCK-QUERY']]),
+              },
+            })
+          : reject(new Error('Not AQL Query'));
+      });
+    });
+
+    expect(await globalManager.getTransactionConfig('test-ruleid', 'test-cfg')).toEqual([['MOCK-QUERY']]);
+  });
+
   it('should not try use cache for getTypologyConfig when cached not enabled', async () => {
     const confConfig = {
       configuration: {
@@ -517,6 +553,22 @@ describe('CreateDatabaseManager', () => {
     expect(await dbManager.getTypologyConfig(getMockTypology())).toEqual(['MOCK-QUERY']);
 
     dbManager.quit();
+  });
+
+  it('should not try use cache for getTypologyConfig when cached not enabled', async () => {
+    jest.spyOn(globalManager._configuration, 'query').mockImplementation((query: string | AqlLiteral): Promise<any> => {
+      return new Promise((resolve, reject) => {
+        isAqlQuery(query)
+          ? resolve({
+              batches: {
+                all: jest.fn().mockImplementation(() => [['MOCK-QUERY']]),
+              },
+            })
+          : reject(new Error('Not AQL Query'));
+      });
+    });
+
+    expect(await globalManager.getTypologyConfig(getMockTypology())).toEqual([['MOCK-QUERY']]);
   });
 
   it('should use cert if path valid', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.0.0-rc.3",
+  "version": "5.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "5.0.0-rc.3",
+      "version": "5.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.0.0-rc.3",
+  "version": "5.0.0-rc.4",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/helpers/proto/Full.proto
+++ b/src/helpers/proto/Full.proto
@@ -493,11 +493,18 @@ message FRMSMessage {
         string ccy = 2;
       }
 
-      DataCacheAmt amt = 5;
+      message DataCacheIntBkSttlmAmt {
+        double amt = 1;
+        string ccy = 2;
+      }
 
-      reserved 6;
+      DataCacheAmt instdAmt = 5;
+      DataCacheIntBkSttlmAmt Intrbksttlmamt = 6;
+
+
+      reserved 7;
       reserved "CreDtTm";
-      string creDtTm = 7;
+      string creDtTm = 8;
     }
 
     message ConditionEdge {

--- a/src/helpers/proto/Full.proto
+++ b/src/helpers/proto/Full.proto
@@ -111,6 +111,7 @@ message FRMSMessage {
     message Eqvtamt {
         Amt Amt = 1;
         string CcyOfTrf = 2;
+        optional double XchgRate = 3;
     }
 
     message Amt1 {
@@ -184,13 +185,14 @@ message FRMSMessage {
         Pmttpinf PmtTpInf = 2;
         Amt1 Amt = 3;
         string ChrgBr = 4;
-        Cdtragt CdtrAgt = 5;
-        Cdtr Cdtr = 6;
-        Cdtracct CdtrAcct = 7;
-        Purp Purp = 8;
-        Rgltryrptg RgltryRptg = 9;
-        Rmtinf RmtInf = 10;
-        SplmtrydataPain001 SplmtryData = 11;
+        optional double XchgRate = 5;
+        Cdtragt CdtrAgt = 6;
+        Cdtr Cdtr = 7;
+        Cdtracct CdtrAcct = 8;
+        Purp Purp = 9;
+        Rgltryrptg RgltryRptg = 10;
+        Rmtinf RmtInf = 11;
+        SplmtrydataPain001 SplmtryData = 12;
     }
 
     message Pmtinf {
@@ -499,12 +501,13 @@ message FRMSMessage {
       }
 
       DataCacheAmt instdAmt = 5;
-      DataCacheIntBkSttlmAmt Intrbksttlmamt = 6;
+      DataCacheIntBkSttlmAmt intrBkSttlmAmt = 6;
+      optional double xchgRate = 7;
 
 
-      reserved 7;
+      reserved 8;
       reserved "CreDtTm";
-      string creDtTm = 8;
+      string creDtTm = 9;
     }
 
     message ConditionEdge {

--- a/src/interfaces/Pacs.008.001.10.ts
+++ b/src/interfaces/Pacs.008.001.10.ts
@@ -22,6 +22,7 @@ interface CdtTrfTxInf {
   IntrBkSttlmAmt: InstdAmtClass;
   InstdAmt: InstdAmtClass;
   ChrgBr: string;
+  XchgRate?: number;
   ChrgsInf: ChrgsInf;
   InitgPty: Cdtr;
   Dbtr: Cdtr;

--- a/src/interfaces/Pain.001.001.11.ts
+++ b/src/interfaces/Pain.001.001.11.ts
@@ -89,6 +89,7 @@ interface Amt {
 interface EqvtAmt {
   Amt: DbtrFinSvcsPrvdrFeesClass;
   CcyOfTrf: string;
+  XchgRate?: number;
 }
 
 interface DbtrFinSvcsPrvdrFeesClass {

--- a/src/interfaces/rule/DataCache.ts
+++ b/src/interfaces/rule/DataCache.ts
@@ -15,4 +15,5 @@ export interface DataCache {
     amt: number;
     ccy: string;
   };
+  xchgRate: number;
 }

--- a/src/interfaces/rule/DataCache.ts
+++ b/src/interfaces/rule/DataCache.ts
@@ -15,5 +15,5 @@ export interface DataCache {
     amt: number;
     ccy: string;
   };
-  xchgRate: number;
+  xchgRate?: number;
 }

--- a/src/interfaces/rule/DataCache.ts
+++ b/src/interfaces/rule/DataCache.ts
@@ -6,9 +6,13 @@ export interface DataCache {
   dbtrAcctId?: string;
   cdtrAcctId?: string;
   evtId?: string;
-  amt?: {
+  creDtTm?: string;
+  instdAmt?: {
     amt: number;
     ccy: string;
   };
-  creDtTm?: string;
+  intrBkSttlmAmt?: {
+    amt: number;
+    ccy: string;
+  };
 }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

We added the intrBkSttlmAmt property to the datacache and updated some out of date tests

## Why are we doing this?

So we can support multi-currency transactions. The tests were required for coverage.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done