### PR TITLE
refactor: update arango schema

### DIFF
--- a/__tests__/collections.test.ts
+++ b/__tests__/collections.test.ts
@@ -1,19 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { dbConfiguration, dbPseudonyms, dbTransactions } from '../src/interfaces/ArangoCollections';
+import { dbConfiguration, dbPseudonyms, dbEvaluateResults, dbTransactionsHistory } from '../src/interfaces/ArangoCollections';
 
 describe('Should point to correct collections in transactionHistory', () => {
   test('transactionHistoryPacs008', () => {
-    expect(dbTransactions.pacs008).toBe('transactionHistoryPacs008');
+    expect(dbTransactionsHistory.pacs008).toBe('transactionHistoryPacs008');
   });
 
   test('transactionHistoryPacs002', () => {
-    expect(dbTransactions.pacs002).toBe('transactionHistoryPacs002');
+    expect(dbTransactionsHistory.pacs002).toBe('transactionHistoryPacs002');
   });
 
   test('transactionHistoryPain001', () => {
-    expect(dbTransactions.pain001).toBe('transactionHistoryPain001');
+    expect(dbTransactionsHistory.pain001).toBe('transactionHistoryPain001');
   });
+});
+
+describe('Should point to correct collections in evaluateResult', () => {
+  expect(dbEvaluateResults.transactions).toBe('transactions');
 });
 
 describe('Should point to correct collections in pseudonyms', () => {
@@ -53,3 +57,4 @@ describe('Should point to correct collections in networkmap', () => {
     expect(dbConfiguration.networkConfiguration).toBe('networkConfiguration');
   });
 });
+``;

--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -3,7 +3,18 @@
 import { AqlLiteral, isAqlQuery } from 'arangojs/aql';
 import { ConfigurationDB, PseudonymsDB, RedisService, TransactionDB, TransactionHistoryDB } from '../src';
 import * as isDatabaseReady from '../src/helpers/readyCheck';
-import { AccountType, ConditionEdge, EntityCondition, NetworkMap, Pacs002, TransactionRelationship, Typology } from '../src/interfaces';
+import {
+  AccountType,
+  ConditionEdge,
+  EntityCondition,
+  NetworkMap,
+  Pacs002,
+  Pacs008,
+  Pain001,
+  Pain013,
+  TransactionRelationship,
+  Typology,
+} from '../src/interfaces';
 import { CreateDatabaseManager, DatabaseManagerInstance, LocalCacheConfig, ManagerConfig } from '../src/services/dbManager';
 
 // redis and aragojs are mocked
@@ -194,6 +205,10 @@ describe('CreateDatabaseManager', () => {
     expect(dbManager.getAccountHistoryPacs008Msgs).toBeDefined();
     expect(dbManager.saveTransactionHistory).toBeDefined();
     expect(dbManager.insertTransaction).toBeDefined();
+    expect(dbManager.saveTransactionHistoryPain001).toBeDefined();
+    expect(dbManager.saveTransactionHistoryPain013).toBeDefined();
+    expect(dbManager.saveTransactionHistoryPacs008).toBeDefined();
+    expect(dbManager.saveTransactionHistoryPacs002).toBeDefined();
 
     expect(await dbManager.queryTransactionDB('testCollection', 'testFilter')).toEqual(['MOCK-QUERY']);
     expect(await dbManager.queryTransactionDB('testCollection', 'testFilter', 10)).toEqual(['MOCK-QUERY']);
@@ -209,7 +224,10 @@ describe('CreateDatabaseManager', () => {
     expect(await dbManager.getAccountEndToEndIds('test', AccountType.DebtorAcct)).toEqual(['MOCK-QUERY']);
     expect(await dbManager.getAccountHistoryPacs008Msgs('test', AccountType.CreditorAcct)).toEqual(['MOCK-QUERY']);
     expect(await dbManager.getAccountHistoryPacs008Msgs('test', AccountType.DebtorAcct)).toEqual(['MOCK-QUERY']);
-    expect(await dbManager.saveTransactionHistory(testPacs002, 'testCollection')).toEqual('MOCK-SAVE');
+    expect(await dbManager.saveTransactionHistoryPain001(testPacs002 as unknown as Pain001)).toEqual('MOCK-SAVE');
+    expect(await dbManager.saveTransactionHistoryPain013(testPacs002 as unknown as Pain013)).toEqual('MOCK-SAVE');
+    expect(await dbManager.saveTransactionHistoryPacs008(testPacs002 as unknown as Pacs008)).toEqual('MOCK-SAVE');
+    expect(await dbManager.saveTransactionHistoryPacs002(testPacs002)).toEqual('MOCK-SAVE');
     expect(await dbManager.insertTransaction('testID', testPacs002, testNetworkMap, {})).toEqual('MOCK-SAVE');
   });
 

--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -753,7 +753,7 @@ describe('CreateDatabaseManager', () => {
     const dbManager: typeof testTypes = localManager as any;
 
     expect(dbManager.getReportByMessageId).toBeDefined();
-    expect(await dbManager.getReportByMessageId('testCollection', 'MSGID')).toEqual(['MOCK-QUERY']);
+    expect(await dbManager.getReportByMessageId('MSGID')).toEqual(['MOCK-QUERY']);
   });
 
   it('should error gracefully on isReadyCheck for database builders', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.0.0-rc.4",
+  "version": "5.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "5.0.0-rc.4",
+      "version": "5.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.0.0-rc.4",
+  "version": "5.0.0-rc.5",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/builders/transactionBuilder.ts
+++ b/src/builders/transactionBuilder.ts
@@ -43,8 +43,8 @@ export async function transactionBuilder(manager: DatabaseManagerType, transacti
     return await (await manager._transaction?.query(query))?.batches.all();
   };
 
-  manager.getReportByMessageId = async (collection: string, messageid: string) => {
-    const db = manager._transaction?.collection(collection);
+  manager.getReportByMessageId = async (messageid: string) => {
+    const db = manager._transaction?.collection(dbEvaluateResults.transactions);
     const messageidAql = aql`${messageid}`;
 
     const query: AqlQuery = aql`

--- a/src/builders/transactionBuilder.ts
+++ b/src/builders/transactionBuilder.ts
@@ -6,6 +6,7 @@ import { type DBConfig, type DatabaseManagerType, readyChecks } from '../service
 import { isDatabaseReady } from '../helpers/readyCheck';
 import { type AqlQuery, aql } from 'arangojs/aql';
 import { type NetworkMap } from '../interfaces';
+import { dbEvaluateResults } from '../interfaces/ArangoCollections';
 
 export async function transactionBuilder(manager: DatabaseManagerType, transactionHistoryConfig: DBConfig, redis: boolean): Promise<void> {
   manager._transaction = new Database({
@@ -63,6 +64,6 @@ export async function transactionBuilder(manager: DatabaseManagerType, transacti
       report: alert,
     };
 
-    return await manager._transaction?.collection('transactions').save(data, { overwriteMode: 'ignore' });
+    return await manager._transaction?.collection(dbEvaluateResults.transactions).save(data, { overwriteMode: 'ignore' });
   };
 }

--- a/src/builders/transactionHistoryBuilder.ts
+++ b/src/builders/transactionHistoryBuilder.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { formatError } from '../helpers/formatter';
 import { isDatabaseReady } from '../helpers/readyCheck';
 import { AccountType, type NetworkMap, type Pacs002, type Pacs008, type Pain001, type Pain013 } from '../interfaces';
-import { dbTransactions } from '../interfaces/ArangoCollections';
+import { dbEvaluateResults, dbTransactionsHistory } from '../interfaces/ArangoCollections';
 import { readyChecks, type DatabaseManagerType, type DBConfig } from '../services/dbManager';
 
 export async function transactionHistoryBuilder(
@@ -50,7 +50,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getTransactionPacs008 = async (endToEndId: string) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pacs008);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs008);
 
     const query: AqlQuery = aql`
         FOR doc IN ${db}
@@ -62,7 +62,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getTransactionPain001 = async (endToEndId: string) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pain001);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pain001);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -74,7 +74,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getDebtorPain001Msgs = async (debtorId: string) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pain001);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pain001);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -88,7 +88,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getCreditorPain001Msgs = async (creditorId: string) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pain001);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pain001);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -102,7 +102,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getSuccessfulPacs002Msgs = async (endToEndId: string) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pacs002);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs002);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -117,7 +117,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getSuccessfulPacs002EndToEndIds = async (endToEndIds: string[]) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pacs002);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs002);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -130,7 +130,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getDebtorPacs002Msgs = async (endToEndId: string) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pacs002);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs002);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -142,7 +142,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getEquivalentPain001Msg = async (endToEndIds: string[]) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pain001);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pain001);
 
     const query: AqlQuery = aql`
       FOR doc IN ${db}
@@ -155,7 +155,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getAccountEndToEndIds = async (accountId: string, accountType: AccountType) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pacs008);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs008);
     const filterType =
       accountType === AccountType.CreditorAcct
         ? aql`FILTER ${accountId} IN doc.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.Othr[*].Id`
@@ -174,7 +174,7 @@ export async function transactionHistoryBuilder(
   };
 
   manager.getAccountHistoryPacs008Msgs = async (accountId: string, accountType: AccountType) => {
-    const db = manager._transactionHistory?.collection(dbTransactions.pacs008);
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs008);
     const filterType =
       accountType === AccountType.CreditorAcct
         ? aql`FILTER ${accountId} IN doc.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.Othr[*].Id`
@@ -198,12 +198,32 @@ export async function transactionHistoryBuilder(
         report: alert,
       };
 
-      return await manager._transactionHistory?.collection(dbTransactions.transactions).save(data, { overwriteMode: 'ignore' });
+      return await manager._transactionHistory?.collection(dbEvaluateResults.transactions).save(data, { overwriteMode: 'ignore' });
     };
   }
 
   manager.saveTransactionHistory = async (tran: Pain001 | Pain013 | Pacs008 | Pacs002, col: string) => {
     const db = manager._transactionHistory?.collection(col);
+    return await db?.save(tran, { overwriteMode: 'ignore' });
+  };
+
+  manager.saveTransactionHistoryPain001 = async (tran: Pain001) => {
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pain001);
+    return await db?.save(tran, { overwriteMode: 'ignore' });
+  };
+
+  manager.saveTransactionHistoryPain013 = async (tran: Pain013) => {
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pain013);
+    return await db?.save(tran, { overwriteMode: 'ignore' });
+  };
+
+  manager.saveTransactionHistoryPacs008 = async (tran: Pacs008) => {
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs008);
+    return await db?.save(tran, { overwriteMode: 'ignore' });
+  };
+
+  manager.saveTransactionHistoryPacs002 = async (tran: Pacs002) => {
+    const db = manager._transactionHistory?.collection(dbTransactionsHistory.pacs002);
     return await db?.save(tran, { overwriteMode: 'ignore' });
   };
 }

--- a/src/interfaces/ArangoCollections.ts
+++ b/src/interfaces/ArangoCollections.ts
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const schema = {
-  transactions: {
+  evaluateResults: {
+    transactions: 'transactions',
+  },
+  transactionHistory: {
     pacs008: 'transactionHistoryPacs008',
     pacs002: 'transactionHistoryPacs002',
     pain001: 'transactionHistoryPain001',
-    transactions: 'transactions',
+    pain013: 'transactionHistoryPain013',
   },
   pseudonyms: {
     self: 'pseudonyms',
@@ -19,15 +22,16 @@ const schema = {
     governed_as_debtor_account_by: 'governed_as_debtor_account_by',
     governed_as_creditor_account_by: 'governed_as_creditor_account_by',
   },
-  config: {
+  configuration: {
     ruleConfiguration: 'ruleConfiguration',
     typologyConfiguration: 'typologyConfiguration',
     transactionConfiguration: 'transactionConfiguration',
     networkConfiguration: 'networkConfiguration',
   },
 };
-const { transactions, pseudonyms, config } = schema;
-const dbTransactions = Object.freeze(transactions);
+const { transactionHistory, pseudonyms, configuration, evaluateResults } = schema;
+const dbTransactionsHistory = Object.freeze(transactionHistory);
 const dbPseudonyms = Object.freeze(pseudonyms);
-const dbConfiguration = Object.freeze(config);
-export { dbConfiguration, dbPseudonyms, dbTransactions };
+const dbConfiguration = Object.freeze(configuration);
+const dbEvaluateResults = Object.freeze(evaluateResults);
+export { dbConfiguration, dbPseudonyms, dbTransactionsHistory, dbEvaluateResults };

--- a/src/interfaces/database/TransactionDB.ts
+++ b/src/interfaces/database/TransactionDB.ts
@@ -35,7 +35,7 @@ export interface TransactionDB {
    *
    * @memberof TransactionHistoryDB
    */
-  getReportByMessageId: (collection: string, messageid: string) => Promise<unknown>;
+  getReportByMessageId: (messageid: string) => Promise<unknown>;
 
   /* ```
    * const query = aql`

--- a/src/interfaces/database/TransactionHistoryDB.ts
+++ b/src/interfaces/database/TransactionHistoryDB.ts
@@ -205,4 +205,32 @@ export interface TransactionHistoryDB {
    * @memberof TransactionHistoryDB
    */
   saveTransactionHistory: (transaction: Pain001 | Pain013 | Pacs008 | Pacs002, transactionhistorycollection: string) => Promise<unknown>;
+
+  /**
+   * @param transaction Transaction of Type Pain001 to store
+   *
+   * @memberof TransactionHistoryDB
+   */
+  saveTransactionHistoryPain001: (transaction: Pain001) => Promise<unknown>;
+
+  /**
+   * @param transaction Transaction of Type Pain013 to store
+   *
+   * @memberof TransactionHistoryDB
+   */
+  saveTransactionHistoryPain013: (transaction: Pain013) => Promise<unknown>;
+
+  /**
+   * @param transaction Transaction of Type Pacs008 to store
+   *
+   * @memberof TransactionHistoryDB
+   */
+  saveTransactionHistoryPacs008: (transaction: Pacs008) => Promise<unknown>;
+
+  /**
+   * @param transaction Transaction of Type Pacs002 to store
+   *
+   * @memberof TransactionHistoryDB
+   */
+  saveTransactionHistoryPacs002: (transaction: Pacs002) => Promise<unknown>;
 }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
We updated the Arango schema 
We added save transaction history functions

## Why are we doing this?
To allow consistency across the platform
To use the Arango schema for every Arango call functions

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done