### PR TITLE
fix: missing fields in message types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.0.0-rc.5",
+  "version": "5.0.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "5.0.0-rc.5",
+      "version": "5.0.0-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.0.0-rc.5",
+  "version": "5.0.0-rc.6",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/interfaces/Pacs.008.001.10.ts
+++ b/src/interfaces/Pacs.008.001.10.ts
@@ -146,4 +146,14 @@ interface Envlp {
 
 interface Doc {
   Xprtn: Date;
+  InitgPty: DocInitgPty;
+}
+
+interface DocInitgPty {
+  Glctn: Glctn;
+}
+
+interface Glctn {
+  Lat: string;
+  Long: string;
 }

--- a/src/interfaces/Pain.013.001.09.ts
+++ b/src/interfaces/Pain.013.001.09.ts
@@ -163,6 +163,7 @@ interface PurpleDoc {
 
 interface DbtrAcct {
   Id: DbtrAcctID;
+  Nm: string;
 }
 
 interface DbtrAcctID {

--- a/src/tests/data/pacs008.ts
+++ b/src/tests/data/pacs008.ts
@@ -50,6 +50,6 @@ export const Pacs008Sample: Pacs008 = {
     },
     RgltryRptg: { Dtls: { Tp: 'BALANCE OF PAYMENTS', Cd: '100' } },
     RmtInf: { Ustrd: 'Payment of USD 30713.75 from April to Felicia' },
-    SplmtryData: { Envlp: { Doc: { Xprtn: new Date('2023-02-03T07:17:52.216Z') } } },
+    SplmtryData: { Envlp: { Doc: { Xprtn: new Date('2023-02-03T07:17:52.216Z'), InitgPty: { Glctn: { Lat: '20', Long: '20' } } } } },
   },
 };

--- a/src/tests/data/pain013.ts
+++ b/src/tests/data/pain013.ts
@@ -36,7 +36,7 @@ export const Pain013Sample: Pain013 = {
         },
         CtctDtls: { MobNb: '+58-210165155' },
       },
-      DbtrAcct: { Id: { Othr: [{ Id: '+58-210165155', SchmeNm: { Prtry: '+58-210165155' }, Nm: 'PASSPORT' }] } },
+      DbtrAcct: { Nm: 'Test', Id: { Othr: [{ Id: '+58-210165155', SchmeNm: { Prtry: '+58-210165155' }, Nm: 'PASSPORT' }] } },
       DbtrAgt: { FinInstnId: { ClrSysMmbId: { MmbId: 'Horatio Ford' } } },
       CdtTrfTxInf: {
         PmtId: { EndToEndId: '02d5-dd5d-4995-a643-bd31c0a89e7a' },


### PR DESCRIPTION
## What did we change?
Add missing message fields in Pain013 and Pacs008 interfaces

## Why are we doing this?
(linked issues)

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done