### PR TITLE
bug: Fixed data type mismatch

### DIFF
--- a/src/interfaces/processor-files/Alert.ts
+++ b/src/interfaces/processor-files/Alert.ts
@@ -8,6 +8,6 @@ export class Alert {
   evaluationID = v4();
   metaData? = new MetaData();
   status = ''; // eg ALRT
-  timestamp: Date = new Date();
+  timestamp: string = new Date().toISOString();
   tadpResult: TADPResult = new TADPResult();
 }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Updated Report/Alert timestamp to reflect the datatype on the protobuff file

## Why are we doing this?

Because the protopuff file and interfaces needs to be in sync

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done