### PR TITLE
refactor: bump lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.1.0",
+  "version": "5.2.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "5.1.0",
+      "version": "5.2.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.2.0-rc.0",
+  "version": "5.1.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "5.2.0-rc.0",
+      "version": "5.1.1-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.2.0-rc.0",
+  "version": "5.1.1-rc.0",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "5.1.0",
+  "version": "5.2.0-rc.0",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
bump lib version
## Why are we doing this?
to avoid conflict of package's versions
## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done