### PR TITLE
feat: multi-tenancy improvements and amends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "6.0.0-rc.5",
+  "version": "6.0.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "6.0.0-rc.5",
+      "version": "6.0.0-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "6.0.0-rc.5",
+  "version": "6.0.0-rc.6",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/builders/configurationBuilder.ts
+++ b/src/builders/configurationBuilder.ts
@@ -99,7 +99,7 @@ export async function configurationBuilder(
   };
 
   manager.getTypologyConfig = async (typology: Typology) => {
-    const cacheKey = `${typology.id}_${typology.cfg}`;
+    const cacheKey = `${typology.tenantId}_${typology.id}_${typology.cfg}`;
     if (cacheConfig?.localCacheEnabled ?? false) {
       const cacheVal = manager.nodeCache?.get(cacheKey);
       if (cacheVal) return await Promise.resolve(cacheVal);
@@ -107,7 +107,7 @@ export async function configurationBuilder(
     const db = manager._configuration?.collection(dbConfiguration.typologyConfiguration);
     const query: AqlQuery = aql`
       FOR doc IN ${db}
-      FILTER doc.id == ${typology.id} AND doc.cfg == ${typology.cfg}
+      FILTER doc.id == ${typology.id} AND doc.cfg == ${typology.cfg} AND doc.tenantId == ${typology.tenantId}
       RETURN doc
     `;
 

--- a/src/helpers/proto/Full.proto
+++ b/src/helpers/proto/Full.proto
@@ -394,6 +394,7 @@ message FRMSMessage {
         string desc = 5;
         uint32 prcgTm = 6;
         uint32 wght = 7;
+        string tenantId = 8;
     }
 
     message Typologyresult {

--- a/src/helpers/proto/Full.proto
+++ b/src/helpers/proto/Full.proto
@@ -362,6 +362,7 @@ message FRMSMessage {
         string host = 2;
         string cfg = 3;
         repeated Rules rules = 4;
+        string tenantId = 5;
     }
 
     message Messages {
@@ -376,6 +377,7 @@ message FRMSMessage {
         bool active = 1;
         string cfg = 2;
         repeated Messages messages = 3;
+        string tenantId = 4;
     }
 
     message Metadata {
@@ -396,6 +398,7 @@ message FRMSMessage {
 
     message Typologyresult {
         string id = 1;
+        string tenantId = 10;
         string cfg = 2;
         string desc = 3;
         uint32 result = 4;
@@ -515,6 +518,7 @@ message FRMSMessage {
       repeated string evtTp = 1;
       string incptnDtTm = 2;
       string xprtnDtTm = 3;
+      string tenantId = 4;
     }
 
 

--- a/src/interfaces/NetworkMap.ts
+++ b/src/interfaces/NetworkMap.ts
@@ -37,6 +37,6 @@ export class Message {
 export class NetworkMap {
   active = false;
   cfg = '';
-  tenantId = 'DEFAULT';
+  tenantId = '';
   messages: Message[] = [];
 }

--- a/src/interfaces/database/ConfigurationDB.ts
+++ b/src/interfaces/database/ConfigurationDB.ts
@@ -64,6 +64,7 @@ export interface ConfigurationDB {
    * const query = aql`
    * FOR doc IN ${collection}
    * FILTER doc.id == ${typology.id} AND doc.cfg == ${typology.cfg}
+   * FILTER doc.tenantId == ${typology.tenantId}
    * RETURN doc`;
    * ```
    * @memberof ConfigurationDB

--- a/src/interfaces/processor-files/TypologyResult.ts
+++ b/src/interfaces/processor-files/TypologyResult.ts
@@ -4,7 +4,7 @@ import type { RuleResult } from '..';
 
 export class TypologyResult {
   id = '';
-  tenantId = 'DEFAULT';
+  tenantId = '';
   cfg = '';
   prcgTm? = 0;
   result = 0.0;

--- a/src/interfaces/rule/RuleResult.ts
+++ b/src/interfaces/rule/RuleResult.ts
@@ -2,6 +2,7 @@
 
 export class RuleResult {
   id = '';
+  tenantId = '';
   cfg = '';
   subRuleRef = '';
   reason? = '';


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
### Required for typology-processor & tadproc
-	In the configuration builder the cacheKey for getTypologyConfig was updated to include `tenantId`.
-	getTypologyConfig interface updated with `tenantId`.
-	getTypologyConfig now filters with `tenantId`.
-	RuleResults now include `tenantId`.
-	RuleResults now include `tenantId` in protobuf.
-	As there can now be multiple networkMaps the networkMapIdentifiers functions were updated to return ruleIds and typologyCfg for all active networkMaps for consumer routes. (Used in typology-processor & transaction-aggregation-decision-processor)
-	unwrap was no longer used in networkMapIdentifiers and was therefore removed from imports.

Ref: https://github.com/tazama-lf/typology-processor/issues/301

### Amends
-	Removed 'DEFAULT' from NetworkMap class.

## Why are we doing this?
Missed requirements and amends required an update for multi-tenancy. typology-processor should now comply to the user story provided for multi-tenancy.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done